### PR TITLE
fixed typo for extensions

### DIFF
--- a/webpack.base.config.js
+++ b/webpack.base.config.js
@@ -34,7 +34,7 @@ module.exports = {
       'node_modules',
       'client'
     ],
-    extentions: ['js', 'jsx', 'scss']
+    extensions: ['js', 'jsx', 'scss']
   },
 
   plugins: [


### PR DESCRIPTION
Found a typo for extensions that made imports not working without specifying .js or .jsx. 